### PR TITLE
Retarget injected animations to fighter models

### DIFF
--- a/Scripts/SakugaEngine/Game/GameManager.cs
+++ b/Scripts/SakugaEngine/Game/GameManager.cs
@@ -433,6 +433,25 @@ namespace SakugaEngine.Game
                         var animDup = (Animation)anim.Duplicate();
                         animDup.LoopMode = Animation.LoopModeEnum.Linear;
 
+                        // Retarget tracks to the fighter's AnimationPlayer root so bones actually move.
+                        // When importing Mixamo GLBs the animation tracks are usually authored relative to the
+                        // GLB scene root. If we copy them directly, the paths won't match the fighter model and
+                        // the character stays in a T-pose. Aligning the track paths fixes the mapping.
+                        var sourceRoot = sourcePlayer.RootNode.ToString();
+                        var targetRoot = targetPlayer.RootNode.ToString();
+                        if (!string.IsNullOrEmpty(sourceRoot) && !string.IsNullOrEmpty(targetRoot) && sourceRoot != targetRoot)
+                        {
+                            for (int track = 0; track < animDup.GetTrackCount(); track++)
+                            {
+                                var trackPath = animDup.TrackGetPath(track).ToString();
+                                if (trackPath.StartsWith(sourceRoot))
+                                {
+                                    var retargeted = trackPath.Replace(sourceRoot, targetRoot);
+                                    animDup.TrackSetPath(track, NodePath.FromStringName(retargeted));
+                                }
+                            }
+                        }
+
                         if (library.HasAnimation(kvp.Key))
                             library.RemoveAnimation(kvp.Key);
                         library.AddAnimation(kvp.Key, animDup);


### PR DESCRIPTION
## Summary
- retarget injected shared animations to the fighter animation player root
- ensure copied GLB animations drive the correct skeleton instead of leaving characters in T-pose

## Testing
- Not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949278f57c08328bee09319e3476ed5)