### PR TITLE
Fix animation retargeting for Godot 4

### DIFF
--- a/Scripts/SakugaEngine/Game/GameManager.cs
+++ b/Scripts/SakugaEngine/Game/GameManager.cs
@@ -448,7 +448,6 @@ namespace SakugaEngine.Game
                                 {
                                     var retargeted = trackPath.Replace(sourceRoot, targetRoot);
                                     animDup.TrackSetPath(track, new NodePath(retargeted));
-                                    animDup.TrackSetPath(track, NodePath.FromStringName(retargeted));
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- remove use of unavailable NodePath.FromStringName when retargeting animation tracks so Godot 4 build succeeds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69492dfaa4948328a33267f20928f0a5)