### PR TITLE
Ensure rollback input size matches game loop expectations

### DIFF
--- a/Scripts/PleaseResync/Godot/PleaseResyncManager.cs
+++ b/Scripts/PleaseResync/Godot/PleaseResyncManager.cs
@@ -24,7 +24,7 @@ namespace PleaseResync
         [Export] protected ushort SpectatorDelay = 30;
         [Export] public uint MaxPlayers = 2;
         [Export] public uint MaxSpectators = 8;
-        [Export] protected uint InputSize = 1;
+        [Export] protected uint InputSize = 2;
         private uint DEVICE_ID;
         private uint PingId;
 

--- a/Scripts/SakugaEngine/Game/GameManager.cs
+++ b/Scripts/SakugaEngine/Game/GameManager.cs
@@ -202,6 +202,13 @@ namespace SakugaEngine.Game
 
         public void GameLoop(byte[] playerInput)
         {
+            int expectedInputSize = (int)(InputSize * Fighters.Length);
+            if (playerInput == null || playerInput.Length < expectedInputSize)
+            {
+                GD.PrintErr($"GameLoop: playerInput length ({playerInput?.Length ?? 0}) is smaller than expected ({expectedInputSize}).");
+                return;
+            }
+
             finalSeed = CalculateSeed();
             Global.UpdateRNG(finalSeed);
             Frame++;


### PR DESCRIPTION
## Summary
- default PleaseResync input size to two bytes to match game loop consumption
- add player input length guard in GameManager.GameLoop to prevent crashes when input packets are short

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f701f6448328aea5c243c1b3d963)