### PR TITLE
Add fight intro sequence with spawn markers

### DIFF
--- a/Scenes/Instances/Sakuga_UI.tscn
+++ b/Scenes/Instances/Sakuga_UI.tscn
@@ -17,6 +17,33 @@
 
 [node name="CanvasLayer" type="CanvasLayer"]
 
+[node name="FightBanner" type="Control" parent="."]
+visible = false
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="FightLabel" type="Label" parent="FightBanner"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -200.0
+offset_top = -60.0
+offset_right = 200.0
+offset_bottom = 60.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 72
+text = "FIGHT!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
 [node name="GameHUD_Background" type="Control" parent="." node_paths=PackedStringArray("P1Portrait", "P1Health", "P1LostHealth", "P1Rounds", "P1Combo", "P1Name", "P2Portrait", "P2Health", "P2LostHealth", "P2Rounds", "P2Combo", "P2Name", "Timer", "P1Debug", "P2Debug")]
 layout_mode = 3
 anchors_preset = 15

--- a/Scripts/SakugaEngine/Components/FighterCamera.cs
+++ b/Scripts/SakugaEngine/Components/FighterCamera.cs
@@ -17,12 +17,20 @@ namespace SakugaEngine
 
         private Camera3D charCam;
 
+        private SceneTreeTween introTween;
+
         const float DELTA = 10f / Global.TicksPerSecond;
 
         public override void _Ready()
         {
             charCam = GetNode<Camera3D>("../CanvasLayer/ViewportContainer/Viewport_Foreground/CharacterCamera");
             //audioListener = GetNode<Listener>("Listener");
+        }
+
+        public override void _Process(double delta)
+        {
+            base._Process(delta);
+            SyncCharacterCamera();
         }
 
         public void UpdateCamera(SakugaFighter player1, SakugaFighter player2)
@@ -62,6 +70,54 @@ namespace SakugaEngine
             charCam.Fov = Fov;
 
             //audioListener.GlobalTranslation = new Vector3(Position.X, Position.Y, 0);
+        }
+
+        public Vector3 CalculateFollowPosition(SakugaFighter player1, SakugaFighter player2)
+        {
+            if (player1 == null || player2 == null) return Position;
+
+            Vector3 _p1Position = Global.ToScaledVector3(player1.Body.FixedPosition);
+            Vector3 _p2Position = Global.ToScaledVector3(player2.Body.FixedPosition);
+
+            float playerDistance = Mathf.Clamp(Mathf.Abs(_p2Position.X - _p1Position.X), minDistance, maxDistance);
+            float pl = (playerDistance - minDistance) / (maxDistance - minDistance);
+            float FinalYOffset = Mathf.Lerp(minOffset.Y, maxOffset.Y, pl);
+            float FinalZOffset = Mathf.Lerp(minOffset.X, maxOffset.X, pl);
+
+            float finalCamY = Mathf.Max(Mathf.Max(_p1Position.Y, _p2Position.Y), FinalYOffset);
+            float actualCenter = (_p1Position.X + _p2Position.X) / 2;
+
+            float BoundsAdd = Mathf.Lerp(boundsAdditionalNear, boundsAdditionalFar, pl);
+            Vector3 targetPosition = new Vector3(
+                Mathf.Clamp(actualCenter, minBounds.X + BoundsAdd, maxBounds.X - BoundsAdd),
+                Mathf.Clamp(finalCamY, minBounds.Y, maxBounds.Y),
+                -FinalZOffset);
+
+            return targetPosition;
+        }
+
+        public SceneTreeTween PlayIntroDolly(Vector3 targetPosition, float duration)
+        {
+            introTween?.Kill();
+
+            Vector3 startPosition = targetPosition + new Vector3(0f, 2.5f, -3f);
+            Position = startPosition;
+
+            introTween = CreateTween();
+            introTween.TweenProperty(this, "position", targetPosition, duration)
+                .SetTrans(Tween.TransitionType.Cubic)
+                .SetEase(Tween.EaseType.Out);
+            introTween.TweenCallback(Callable.From(() => introTween = null));
+
+            return introTween;
+        }
+
+        private void SyncCharacterCamera()
+        {
+            if (charCam == null) return;
+
+            charCam.GlobalTransform = GlobalTransform;
+            charCam.Fov = Fov;
         }
     }
 }

--- a/Scripts/SakugaEngine/Components/SakugaFighter.cs
+++ b/Scripts/SakugaEngine/Components/SakugaFighter.cs
@@ -160,6 +160,33 @@ namespace SakugaEngine
             Body.PlayerSide = Body.IsLeftSide ? 1 : -1;
         }
 
+        public int GetStateIndexByName(string stateName)
+        {
+            if (Animator?.States == null || string.IsNullOrEmpty(stateName)) return -1;
+
+            for (int i = 0; i < Animator.States.Length; i++)
+            {
+                if (Animator.States[i] != null && Animator.States[i].StateName == stateName)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        public float GetStateDurationSeconds(int stateIndex)
+        {
+            if (Animator?.States == null || stateIndex < 0 || stateIndex >= Animator.States.Length)
+                return 0f;
+
+            return Animator.States[stateIndex].Duration / (float)Global.TicksPerSecond;
+        }
+
+        public void PlayNeutralState()
+        {
+            Animator.PlayState(Stance.GetCurrentStance().NeutralState, true);
+            Animator.Frame = -1;
+        }
+
         public override void PreTick()
         {
             HitStop.Run();

--- a/Scripts/SakugaEngine/Game/GameManager.cs
+++ b/Scripts/SakugaEngine/Game/GameManager.cs
@@ -33,6 +33,17 @@ namespace SakugaEngine.Game
         private HealthHUD healthHUD;
         private MetersHUD metersHUD;
 
+        private Node3D stageInstance;
+        private bool inputsLocked = true;
+        private bool aiMovementLocked = true;
+        private bool cameraFollowLocked;
+
+        private Control fightBanner;
+        private Label fightLabel;
+
+        private const float fightFlashTime = 0.75f;
+        private const float introDollyDuration = 1.0f;
+
         private int Frame = 0;
         private int generatedSeed = 0;
         private int finalSeed = 0;
@@ -43,6 +54,9 @@ namespace SakugaEngine.Game
         {
             healthHUD = (HealthHUD)FighterUI.GetNode("GameHUD_Background");
             metersHUD = (MetersHUD)FighterUI.GetNode("GameHUD_Foreground");
+            fightBanner = FighterUI.GetNodeOrNull<Control>("FightBanner");
+            fightLabel = fightBanner?.GetNodeOrNull<Label>("FightLabel");
+            if (fightBanner != null) fightBanner.Visible = false;
             Nodes = new();
         }
 
@@ -68,7 +82,8 @@ namespace SakugaEngine.Game
         public void Render()
         {
             RenderNodes();
-            Camera.UpdateCamera(Fighters[0], Fighters[1]);
+            if (!cameraFollowLocked)
+                Camera.UpdateCamera(Fighters[0], Fighters[1]);
             healthHUD.UpdateHealthBars(Fighters, Monitor);
             metersHUD.UpdateMeters(Fighters);
         }
@@ -132,6 +147,11 @@ namespace SakugaEngine.Game
 
             Frame = 0;
 
+            stageInstance = null;
+            inputsLocked = true;
+            aiMovementLocked = true;
+            cameraFollowLocked = false;
+
             CreateStage(selectedStage);
 
             World = new PhysicsWorld();
@@ -163,6 +183,8 @@ namespace SakugaEngine.Game
             if (metersHUD == null && FighterUI != null) metersHUD = (MetersHUD)FighterUI.GetNode("GameHUD_Foreground");
             if (metersHUD != null) metersHUD.Setup(Fighters);
             else GD.PrintErr("GameManager: metersHUD is null! (Check FighterUI connection)");
+
+            StartIntroSequence();
         }
 
         public void CreateFighter(int characterIndex, int playerIndex)
@@ -190,7 +212,98 @@ namespace SakugaEngine.Game
                 stageIndex = 0;
             }
             Node temp = stagesList.elements[stageIndex].Instance.Instantiate();
+            stageInstance = temp as Node3D;
             AddChild(temp);
+        }
+
+        private void PositionFightersAtSpawns()
+        {
+            Vector2I leftPosition = new(-Global.StartingPosition, 0);
+            Vector2I rightPosition = new(Global.StartingPosition, 0);
+
+            if (stageInstance != null)
+            {
+                Node3D spawnRoot = stageInstance.GetNodeOrNull<Node3D>("SpawnMarkers");
+                Vector2I? left = GetSpawnPosition(spawnRoot?.GetNodeOrNull<Node3D>("LeftSpawn"));
+                Vector2I? right = GetSpawnPosition(spawnRoot?.GetNodeOrNull<Node3D>("RightSpawn"));
+
+                if (left.HasValue) leftPosition = left.Value;
+                if (right.HasValue) rightPosition = right.Value;
+            }
+
+            Fighters[0].Body.FixedVelocity = Vector2I.Zero;
+            Fighters[1].Body.FixedVelocity = Vector2I.Zero;
+
+            Fighters[0].Body.FixedPosition = leftPosition;
+            Fighters[1].Body.FixedPosition = rightPosition;
+
+            Fighters[0].ForcePlayerSide(true);
+            Fighters[1].ForcePlayerSide(false);
+
+            Fighters[0].PlayNeutralState();
+            Fighters[1].PlayNeutralState();
+        }
+
+        private Vector2I? GetSpawnPosition(Node3D spawn)
+        {
+            if (spawn == null) return null;
+
+            return new Vector2I(
+                (int)(spawn.GlobalPosition.X * Global.SimulationScale),
+                (int)(spawn.GlobalPosition.Y * Global.SimulationScale)
+            );
+        }
+
+        private float PlayTaunts()
+        {
+            float maxDuration = 0.5f;
+
+            for (int i = 0; i < Fighters.Length; i++)
+            {
+                int tauntIndex = Fighters[i].GetStateIndexByName("Taunt");
+                if (tauntIndex >= 0)
+                {
+                    Fighters[i].Animator.PlayState(tauntIndex, true);
+                    Fighters[i].Animator.Frame = -1;
+                    maxDuration = Mathf.Max(maxDuration, Fighters[i].GetStateDurationSeconds(tauntIndex));
+                }
+                else Fighters[i].PlayNeutralState();
+            }
+
+            return maxDuration;
+        }
+
+        private void ShowFightLabel(bool visible)
+        {
+            if (fightBanner == null) return;
+
+            fightBanner.Visible = visible;
+            if (fightLabel != null) fightLabel.Modulate = Colors.White;
+        }
+
+        private async void StartIntroSequence()
+        {
+            PositionFightersAtSpawns();
+
+            float tauntDuration = PlayTaunts();
+            await ToSignal(GetTree().CreateTimer(tauntDuration), "timeout");
+
+            Fighters[0].PlayNeutralState();
+            Fighters[1].PlayNeutralState();
+
+            Vector3 targetCameraPosition = Camera.CalculateFollowPosition(Fighters[0], Fighters[1]);
+            cameraFollowLocked = true;
+            SceneTreeTween dolly = Camera.PlayIntroDolly(targetCameraPosition, introDollyDuration);
+            if (dolly != null)
+                await ToSignal(dolly, "finished");
+
+            ShowFightLabel(true);
+            await ToSignal(GetTree().CreateTimer(fightFlashTime), "timeout");
+            ShowFightLabel(false);
+
+            cameraFollowLocked = false;
+            inputsLocked = false;
+            aiMovementLocked = false;
         }
 
         public void AddActor(SakugaNode newNode, bool isPhysicsBody = true)
@@ -226,6 +339,12 @@ namespace SakugaEngine.Game
             {
                 if (Fighters[i].UseAI)
                 {
+                    if (inputsLocked || aiMovementLocked)
+                    {
+                        Fighters[i].ParseInputs(0);
+                        continue;
+                    }
+
                     if (Fighters[i].Brain != null)
                     {
                         Fighters[i].Brain.SelectCommand();
@@ -235,6 +354,12 @@ namespace SakugaEngine.Game
                 }
                 else
                 {
+                    if (inputsLocked)
+                    {
+                        Fighters[i].ParseInputs(0);
+                        continue;
+                    }
+
                     ushort combinedInput = 0;
                     combinedInput |= playerInput[i * InputSize];
                     combinedInput |= (ushort)(playerInput[(i * InputSize) + 1] << 8);

--- a/Stages/Sakuga Default/sakuga_stage_basic.tscn
+++ b/Stages/Sakuga Default/sakuga_stage_basic.tscn
@@ -34,3 +34,11 @@ environment = SubResource("Environment_iltph")
 [node name="Floor" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.1, 0)
 mesh = SubResource("BoxMesh_ql5gv")
+
+[node name="SpawnMarkers" type="Node3D" parent="."]
+
+[node name="LeftSpawn" type="Marker3D" parent="SpawnMarkers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.5, 0, 0)
+
+[node name="RightSpawn" type="Marker3D" parent="SpawnMarkers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.5, 0, 0)


### PR DESCRIPTION
## Summary
- position fighters at stage spawn markers, play taunts, and return them to idle before the round begins
- add an intro camera dolly and on-screen FIGHT banner before unlocking player and AI control
- include spawn marker nodes on the default stage and new UI elements for the fight banner

## Testing
- Not run (dotnet tooling not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a4e078060832896f43cdcfb57d29d)